### PR TITLE
Use model relationships for requirement diagnostics

### DIFF
--- a/server/src/model/sysmlModelProvider.ts
+++ b/server/src/model/sysmlModelProvider.ts
@@ -164,6 +164,16 @@ function readCommaSeparatedIdents(text: string, pos: number): string[] {
 }
 
 /**
+ * Replace line and block comments with spaces while preserving line/offset
+ * positions so index-based scans remain valid.
+ */
+function stripComments(text: string): string {
+    return text
+        .replace(/\/\*[\s\S]*?\*\//g, m => m.replace(/[^\n]/g, ' '))
+        .replace(/\/\/[^\n]*/g, m => ' '.repeat(m.length));
+}
+
+/**
  * Provides the full semantic model for a document by converting the
  * server's internal ANTLR parse tree and symbol table into serializable DTOs.
  *
@@ -523,7 +533,7 @@ export class SysMLModelProvider {
         // Scan for standalone satisfy/verify statements that aren't part of any
         // symbol (e.g. top-level `satisfy X by Y;` inside a package).
         const fullText = lines.join('\n');
-        const standaloneSatisfy = this.extractStandaloneSatisfyVerify(fullText);
+        const standaloneSatisfy = this.extractStandaloneSatisfyVerify(stripComments(fullText));
         for (const rel of standaloneSatisfy) {
             // Avoid duplicates — only add if not already present
             const isDup = relationships.some(
@@ -1238,14 +1248,17 @@ export class SysMLModelProvider {
                 const [reqName, afterReq] = readNameOrQuoted(text, pos);
                 if (!reqName || reqName === 'requirement') continue;
 
-                // Look for 'by <satisfier>' clause
+                // Optional 'by <satisfier>' clause
                 const byPos = skipWS(text, afterReq);
                 const [byWord, afterBy] = readIdent(text, byPos);
-                if (byWord !== 'by') continue;  // standalone satisfy/verify must have 'by'
-                const [satisfier] = readNameOrQuoted(text, skipWS(text, afterBy));
-                if (!satisfier) continue;
+                let source = '(standalone)';
+                if (byWord === 'by') {
+                    const [byTarget] = readNameOrQuoted(text, skipWS(text, afterBy));
+                    if (!byTarget) continue;
+                    source = byTarget;
+                }
 
-                rels.push({ type: kw, source: satisfier, target: reqName });
+                rels.push({ type: kw, source, target: reqName });
             }
         }
         return rels;
@@ -1253,6 +1266,7 @@ export class SysMLModelProvider {
 
     /** Extract relationship keywords from element text. */
     private extractKeywordRelationships(elementName: string, elementText: string): RelationshipDTO[] {
+        elementText = stripComments(elementText);
         const rels: RelationshipDTO[] = [];
 
         // subsetting: `subsets X`

--- a/server/src/providers/semanticValidator.ts
+++ b/server/src/providers/semanticValidator.ts
@@ -1,5 +1,6 @@
 import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver/node.js';
 import { DocumentManager } from '../documentManager.js';
+import { SysMLModelProvider } from '../model/sysmlModelProvider.js';
 import { getLibraryPackageNames, resolveLibraryType } from '../library/libraryIndex.js';
 import { SysMLElementKind, SysMLSymbol, isDefinition } from '../symbols/sysmlElements.js';
 
@@ -73,6 +74,8 @@ function isISQValueType(name: string): boolean {
  * - Mandatory features with unresolved types
  */
 export class SemanticValidator {
+    private readonly modelProvider: SysMLModelProvider;
+
     /** Cached workspace-wide satisfy data, invalidated when any document version changes. */
     private satisfyCache?: {
         versionKey: string;
@@ -86,7 +89,44 @@ export class SemanticValidator {
         verifiedNames: Set<string>;
     };
 
-    constructor(private readonly documentManager: DocumentManager) { }
+    constructor(private readonly documentManager: DocumentManager) {
+        this.modelProvider = new SysMLModelProvider(documentManager);
+    }
+
+    private addRequirementNameVariants(out: Set<string>, ref: string | undefined): void {
+        if (!ref) return;
+        const trimmed = ref.trim();
+        if (!trimmed) return;
+        out.add(trimmed);
+        const lastSeg = trimmed.includes('::') ? trimmed.split('::').pop()! : trimmed;
+        out.add(lastSeg);
+    }
+
+    private collectWorkspaceRequirementRelationshipNames(): {
+        satisfiedNames: Set<string>;
+        verifiedNames: Set<string>;
+    } {
+        const satisfiedNames = new Set<string>();
+        const verifiedNames = new Set<string>();
+        const uris = this.documentManager.getUris();
+
+        for (const uri of uris) {
+            const version = this.documentManager.getVersion(uri);
+            if (version < 0) continue;
+
+            const model = this.modelProvider.getModel(uri, version, ['relationships']);
+            const rels = model.relationships ?? [];
+            for (const rel of rels) {
+                if (rel.type === 'satisfy') {
+                    this.addRequirementNameVariants(satisfiedNames, rel.target);
+                } else if (rel.type === 'verify') {
+                    this.addRequirementNameVariants(verifiedNames, rel.target);
+                }
+            }
+        }
+
+        return { satisfiedNames, verifiedNames };
+    }
 
     /**
      * Run all semantic validation rules and return LSP Diagnostic objects.
@@ -588,12 +628,11 @@ export class SemanticValidator {
                 satisfiedNames = this.satisfyCache.satisfiedNames;
                 satisfyBlockRanges = this.satisfyCache.satisfyBlockRanges;
             } else {
-                satisfiedNames = new Set<string>();
+                satisfiedNames = this.collectWorkspaceRequirementRelationshipNames().satisfiedNames;
                 satisfyBlockRanges = new Map();
                 for (const uri of uris) {
                     const text = this.documentManager.getText(uri);
                     if (text) {
-                        this.extractSatisfyReferences(text, satisfiedNames);
                         satisfyBlockRanges.set(uri, this.extractSatisfyBlockRanges(text));
                     }
                 }
@@ -648,8 +687,8 @@ export class SemanticValidator {
      * Adds both the full qualified name and the simple (last segment) name.
      *
      * Patterns matched:
-     *   satisfy QualifiedName by ...
-     *   satisfy QualifiedName;
+    *   satisfy QualifiedName by ...
+    *   satisfy QualifiedName;
      */
     private extractSatisfyReferences(text: string, out: Set<string>): void {
         // Match: satisfy QualifiedName by ...
@@ -754,12 +793,11 @@ export class SemanticValidator {
                 satisfiedNames = this.satisfyCache.satisfiedNames;
                 satisfyBlockRanges = this.satisfyCache.satisfyBlockRanges;
             } else {
-                satisfiedNames = new Set<string>();
+                satisfiedNames = this.collectWorkspaceRequirementRelationshipNames().satisfiedNames;
                 satisfyBlockRanges = new Map();
                 for (const uri of uris) {
                     const text = this.documentManager.getText(uri);
                     if (text) {
-                        this.extractSatisfyReferences(text, satisfiedNames);
                         satisfyBlockRanges.set(uri, this.extractSatisfyBlockRanges(text));
                     }
                 }
@@ -770,13 +808,7 @@ export class SemanticValidator {
             if (this.verifyCache && this.verifyCache.versionKey === versionKey) {
                 verifiedNames = this.verifyCache.verifiedNames;
             } else {
-                verifiedNames = new Set<string>();
-                for (const uri of uris) {
-                    const text = this.documentManager.getText(uri);
-                    if (text) {
-                        this.extractVerifyReferences(text, verifiedNames);
-                    }
-                }
+                verifiedNames = this.collectWorkspaceRequirementRelationshipNames().verifiedNames;
                 this.verifyCache = { versionKey, verifiedNames };
             }
         } else {

--- a/test/unit/diagnostics.test.ts
+++ b/test/unit/diagnostics.test.ts
@@ -540,6 +540,31 @@ package Design {
             expect(unsatisfied.length).toBe(0);
         });
 
+        it('should detect satisfy across files for shorthand satisfy syntax', async () => {
+            const reqText = `
+package Requirements {
+    requirement engineSpec {
+        subject e : Engine;
+    }
+}
+`;
+            const designText = `
+package Design {
+    part def Engine { }
+    satisfy Requirements::engineSpec;
+}
+`;
+            const diags = await getSemanticDiagnosticsForUri(
+                [
+                    { uri: 'file:///requirements.sysml', text: reqText },
+                    { uri: 'file:///design.sysml', text: designText },
+                ],
+                'file:///requirements.sysml',
+            );
+            const unsatisfied = diags.filter(d => d.code === 'unsatisfied-requirement');
+            expect(unsatisfied.length).toBe(0);
+        });
+
         it('should not warn for requirement redefinitions inside satisfy blocks', async () => {
             const text = `
 package Requirements {
@@ -678,6 +703,37 @@ package Design {
 package Verification {
     verification case def EngineTest { }
     verify Requirements::engineSpec by EngineTest;
+}
+`;
+            const diags = await getSemanticDiagnosticsForUri(
+                [
+                    { uri: 'file:///requirements.sysml', text: reqText },
+                    { uri: 'file:///design.sysml', text: designText },
+                    { uri: 'file:///verification.sysml', text: verifyText },
+                ],
+                'file:///requirements.sysml',
+            );
+            const unverified = diags.filter(d => d.code === 'unverified-requirement');
+            expect(unverified.length).toBe(0);
+        });
+
+        it('should detect verify across files for shorthand verify syntax', async () => {
+            const reqText = `
+package Requirements {
+    requirement engineSpec {
+        subject e : Engine;
+    }
+}
+`;
+            const designText = `
+package Design {
+    part def Engine { }
+    satisfy Requirements::engineSpec;
+}
+`;
+            const verifyText = `
+package Verification {
+    verify Requirements::engineSpec;
 }
 `;
             const diags = await getSemanticDiagnosticsForUri(


### PR DESCRIPTION
I'm not used to doing these on GitHub so sorry if I am missing something. I really love your extension.

I ran into an issue were the lsp was telling me that requirements were not satisfied if the sysml model was split across files, so I put together this patch so that all the files in the workspace would be considered instead of just the open file.

Summary
This PR fixes false unsatisfied-requirement and unverified-requirement diagnostics for valid cross-file models by using semantic relationship data instead of text-only scanning in the LSP path.

What changed
- Switched LSP-path requirement satisfy/verify checks in SemanticValidator to use workspace relationship data from SysMLModelProvider.
- Hardened relationship extraction by stripping comments before scanning, so commented-out satisfy/verify statements are ignored.
- Added support for standalone shorthand relationship forms in model extraction:
  - satisfy Qualified::Req;
  - verify Qualified::Req;
- Added regression tests for cross-file shorthand satisfy/verify.

Files
- server/src/providers/semanticValidator.ts
- server/src/model/sysmlModelProvider.ts
- test/unit/diagnostics.test.ts

Validation
- Targeted diagnostics suite: npm test -- test/unit/diagnostics.test.ts
- Full test suite: npm test (308/308)

Why this approach
This keeps diagnostics aligned with SysML v2 semantics and the existing model/symbol pipeline, rather than relying on text pattern matching for cross-file requirement relationships.

Notes
- Commit is signed.
- PR is opened as draft for maintainer review and discussion.
