### PR TITLE
Create super type graph

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -45,6 +45,11 @@ A Language Server Protocol implementation for SysML v2, structured as a client/s
 - **scope.ts** — Manages nested lexical scopes for name resolution (package → definition → usage).
 - **sysmlElements.ts** — Type definitions for SysML element kinds (PartDef, PartUsage, etc.).
 
+### Analysis Layer (`server/src/analysis/`)
+
+- **typeGraph.ts** — Builds a **super-type graph** with *kinded* edges (specialization, subsetting, redefinition, feature-typing, and injected implicit defaults). Every definition is automatically linked to the standard-library root type for its kind (e.g. `part def Wheel` → `Parts::Part`), and the fixed library backbone hierarchy (`Part :> Item :> Object :> Occurrence`, …) is seeded so cross-kind reasoning works without parsing the full library. A depth-first search (DFS) answers "does type A specialize type B?". Consumed by `SemanticValidator` for the `incompatible-specialization` type-error check.
+- **complexityAnalyzer.ts** — Computes model complexity metrics for the complexity code lens.
+
 ### Provider Layer (`server/src/providers/`)
 
 Each LSP feature is implemented as a standalone provider class:

--- a/examples/allowed-cycles.sysml
+++ b/examples/allowed-cycles.sysml
@@ -1,0 +1,80 @@
+/**
+ * Allowed Cyclical Types Example
+ *
+ * Not every cycle is an error. SysML v2 permits a definition to reference
+ * *itself* — recursive decomposition — because each instance terminates the
+ * recursion in practice (a tree has leaf nodes, an org chart has individual
+ * contributors, and so on). The language server distinguishes these valid
+ * self-referential patterns from the genuine cycles flagged in
+ * `type-errors.sysml`.
+ *
+ * None of the definitions below should produce a `circular-containment` or
+ * `circular-specialization` diagnostic. Verify with:
+ *
+ *   python3 clients/python/sysml_lsp_client.py examples/allowed-cycles.sysml
+ */
+package AllowedCycles {
+
+    // ── 1. Recursive behaviour (self-typed action feature) ────────────────
+    // An action that decomposes into sub-actions of the *same* kind. The `[*]`
+    // multiplicity allows zero sub-functions, so the recursion bottoms out.
+    abstract action def Function {
+        doc /* A behaviour that may decompose into sub-functions of its own kind. */
+        action subfunctions[*] : Function;
+    }
+
+    // ── 2. Recursive structure (tree / composite pattern) ─────────────────
+    // A classic tree: every node may own any number of child nodes of its own
+    // type. Leaf nodes simply have zero children.
+    part def TreeNode {
+        doc /* A node that may own any number of child nodes of the same type. */
+        part children[*] : TreeNode;
+    }
+
+    // ── 3. Recursive assembly (parts made of sub-parts) ───────────────────
+    // An assembly that contains further sub-assemblies. Bounded multiplicity
+    // makes the intent explicit but the self-reference is still valid.
+    part def Assembly {
+        doc /* An assembly that may contain bounded sub-assemblies of its own type. */
+        part subassemblies[0..10] : Assembly;
+        part fasteners[*] : Fastener;
+    }
+
+    part def Fastener {
+        doc /* A component used to join assemblies together. */
+    }
+
+    // ── 4. Recursive organisation (manager → reports) ─────────────────────
+    // An employee who manages other employees. Optional `manager` and any
+    // number of `reports`, all typed by the same definition.
+    part def Employee {
+        doc /* A person who may manage, and be managed by, other employees. */
+        ref part manager[0..1] : Employee;
+        part reports[*] : Employee;
+        attribute name : String;
+    }
+
+    // ── 5. Self-referential data structure (linked list) ──────────────────
+    // A node that optionally points to the next node — the data-value
+    // equivalent of recursive structure.
+    item def ListNode {
+        doc /* A list element that optionally points to the next element. */
+        attribute value : Integer;
+        ref item next[0..1] : ListNode;
+    }
+
+    // ── 6. Mutually recursive trees that DO terminate ─────────────────────
+    // Folder contains Files and sub-Folders. Files never contain Folders, so
+    // there is no mutual-containment cycle — only the Folder self-reference,
+    // which is allowed.
+    part def Folder {
+        doc /* A folder that may contain files and nested sub-folders. */
+        part files[*] : File;
+        part subfolders[*] : Folder;
+    }
+
+    part def File {
+        doc /* A leaf node that never contains folders, so no cycle forms. */
+        attribute sizeBytes : Integer;
+    }
+}

--- a/examples/type-errors.sysml
+++ b/examples/type-errors.sysml
@@ -1,0 +1,73 @@
+/**
+ * Type Errors Example
+ *
+ * Every definition in this package deliberately violates one of the SysML v2
+ * semantic type-checking rules. Open it with the language server to see the
+ * diagnostics, or run:
+ *
+ *   python3 clients/python/sysml_lsp_client.py examples/type-errors.sysml
+ *
+ * For each section the expected diagnostic `code` is noted in a comment.
+ */
+package TypeErrors {
+
+    // ── 1. Incompatible specialization (disjoint type families) ───────────
+    // `part def` is rooted at Parts::Part (occurrence family); `attribute def`
+    // is rooted at Base::DataValue (data family). A part may not specialize a
+    // data value — they belong to disjoint type families.
+    // → code: incompatible-specialization
+    attribute def Mass;
+
+    part def Wheel :> Mass;
+
+    // The reverse direction is equally invalid: a data value cannot specialize
+    // an occurrence.
+    // → code: incompatible-specialization
+    part def Person;
+
+    attribute def ForceUnit :> Person;
+
+    // ── 2. Circular specialization chain ──────────────────────────────────
+    // A :> B, B :> C, C :> A forms a generalization cycle. A type cannot be
+    // its own (transitive) super-type.
+    // → code: circular-specialization
+    part def A :> C;
+
+    part def B :> A;
+
+    part def C :> B;
+
+    // ── 3. Circular containment (mutual ownership) ────────────────────────
+    // Container owns a feature typed by Contained, and Contained owns a
+    // feature typed by Container — an infinite containment loop.
+    // → code: circular-containment
+    part def Container {
+        part inner : Contained;
+    }
+
+    part def Contained {
+        part outer : Container;
+    }
+
+    // ── 4. Unresolved type reference ──────────────────────────────────────
+    // `Gearbox` is never defined anywhere in the workspace.
+    // → code: unresolved-type
+    part def Transmission {
+        part gearbox : Gearbox;
+    }
+
+    // ── 5. Invalid multiplicity bounds ────────────────────────────────────
+    // The lower bound (5) exceeds the upper bound (2).
+    // → code: invalid-multiplicity
+    part def Axle {
+        part bearings : Bearing[5..2];
+    }
+
+    part def Bearing;
+
+    // ── 6. Empty enumeration ──────────────────────────────────────────────
+    // An enum definition that declares no values is almost certainly a
+    // mistake.
+    // → code: empty-enum
+    enum def Color;
+}

--- a/server/src/analysis/typeGraph.ts
+++ b/server/src/analysis/typeGraph.ts
@@ -1,0 +1,325 @@
+import { SysMLElementKind, SysMLSymbol, isDefinition } from '../symbols/sysmlElements.js';
+
+/**
+ * Super-type graph for SysML v2 type checking.
+ *
+ * The graph models the SysML v2 generalization relationships between
+ * types as a directed graph whose edges point from a type to each of its
+ * super-types.  Edges are *kinded* — every edge records *why* the target
+ * is a super-type of the source (explicit specialization, subsetting,
+ * redefinition, feature typing, or an implicit/default super-type that the
+ * language injects automatically).
+ *
+ * Two capabilities are built on top of the graph:
+ *
+ *  1. {@link SuperTypeGraph.specializes} — a depth-first search (DFS) that
+ *     answers "does type A specialize (directly or transitively) type B?".
+ *  2. Implicit super-type injection — every definition is automatically
+ *     linked to the root library type for its kind (e.g. `part def Wheel`
+ *     gains an implicit edge to `Parts::Part`), mirroring the implicit
+ *     generalizations defined by the SysML v2 specification and the Pilot
+ *     Implementation.
+ *
+ * Node identity is the *simple* (unqualified) type name — the last segment
+ * of a qualified reference such as `ISQ::MassValue` → `MassValue`.  This
+ * matches how the symbol table indexes names and keeps lookups robust
+ * whether references are written qualified or unqualified.
+ */
+
+/** The reason a target node is a super-type of a source node. */
+export enum EdgeKind {
+    /** Explicit `:>` / `specializes` / `subclassifier` on a definition. */
+    Specialization = 'specialization',
+    /** Explicit `:>` / `subsets` on a usage (feature). */
+    Subsetting = 'subsetting',
+    /** Explicit `:>>` / `redefines` on a usage (feature). */
+    Redefinition = 'redefinition',
+    /** Explicit `:` / `typed by` — a usage typed by its definition. */
+    FeatureTyping = 'feature-typing',
+    /** Injected default super-type for the element's kind (e.g. `Parts::Part`). */
+    Implicit = 'implicit',
+}
+
+/** A directed, kinded super-type edge. */
+export interface SuperTypeEdge {
+    /** Simple name of the super-type node this edge points to. */
+    readonly target: string;
+    /** Why {@link target} is a super-type of the source node. */
+    readonly kind: EdgeKind;
+    /** The reference text as written (may be qualified, e.g. `Parts::Part`). */
+    readonly reference: string;
+}
+
+/**
+ * The implicit (default) super-type injected for each definition kind.
+ *
+ * Mirrors the implicit generalization map of the SysML v2 specification and
+ * the Systems-Modeling Pilot Implementation.  Each entry maps a definition
+ * kind to the qualified name of the standard-library type it implicitly
+ * specializes.  The simple name (last segment) is used as the graph node.
+ *
+ * @see https://github.com/Systems-Modeling/SysML-v2-Pilot-Implementation
+ * @see sysml.library/Systems Library (Parts.sysml, Items.sysml, …)
+ */
+export const IMPLICIT_DEFINITION_SUPERTYPES: ReadonlyMap<SysMLElementKind, string> = new Map([
+    [SysMLElementKind.PartDef, 'Parts::Part'],
+    [SysMLElementKind.ItemDef, 'Items::Item'],
+    [SysMLElementKind.AttributeDef, 'Base::DataValue'],
+    [SysMLElementKind.EnumDef, 'Base::DataValue'],
+    [SysMLElementKind.PortDef, 'Ports::Port'],
+    [SysMLElementKind.ConnectionDef, 'Connections::Connection'],
+    [SysMLElementKind.InterfaceDef, 'Interfaces::Interface'],
+    [SysMLElementKind.AllocationDef, 'Allocations::Allocation'],
+    [SysMLElementKind.ActionDef, 'Actions::Action'],
+    [SysMLElementKind.StateDef, 'States::StateAction'],
+    [SysMLElementKind.CalcDef, 'Calculations::Calculation'],
+    [SysMLElementKind.ConstraintDef, 'Constraints::ConstraintCheck'],
+    [SysMLElementKind.RequirementDef, 'Requirements::RequirementCheck'],
+    [SysMLElementKind.UseCaseDef, 'UseCases::UseCase'],
+    [SysMLElementKind.AnalysisCaseDef, 'AnalysisCases::AnalysisCase'],
+    [SysMLElementKind.VerificationCaseDef, 'VerificationCases::VerificationCase'],
+    [SysMLElementKind.ViewDef, 'Views::View'],
+    [SysMLElementKind.ViewpointDef, 'Views::Viewpoint'],
+    [SysMLElementKind.RenderingDef, 'Views::Rendering'],
+    [SysMLElementKind.OccurrenceDef, 'Occurrences::Occurrence'],
+    [SysMLElementKind.MetadataDef, 'Metaobjects::Metaobject'],
+]);
+
+/**
+ * Specialization edges that hold *within* the standard library between the
+ * implicit root types.  These let the DFS reason across kinds (for example
+ * `Part :> Item :> Object :> Occurrence`) without requiring the bundled
+ * library to be fully parsed into the workspace symbol table.
+ *
+ * Sourced from the bundled `sysml.library` (e.g. `part def Part :> Item`,
+ * `item def Item :> Object`).  Targets are simple names.
+ */
+const BASE_TYPE_HIERARCHY: ReadonlyArray<readonly [string, string]> = [
+    ['Part', 'Item'],
+    ['Item', 'Object'],
+    ['Object', 'Occurrence'],
+    ['Action', 'Occurrence'],
+    ['StateAction', 'Action'],
+    ['Calculation', 'Action'],
+    ['ConstraintCheck', 'BooleanEvaluation'],
+    ['RequirementCheck', 'ConstraintCheck'],
+    ['Case', 'Calculation'],
+    ['AnalysisCase', 'Case'],
+    ['VerificationCase', 'Case'],
+    ['UseCase', 'Case'],
+    ['Connection', 'Part'],
+    ['Interface', 'Connection'],
+    ['Allocation', 'Connection'],
+    ['Occurrence', 'Anything'],
+    ['DataValue', 'Anything'],
+    ['Port', 'Occurrence'],
+    ['View', 'Part'],
+    ['Viewpoint', 'RequirementCheck'],
+    ['Rendering', 'Part'],
+    ['Metaobject', 'Anything'],
+];
+
+/**
+ * The two disjoint top-level families of the SysML v2 type system, rooted
+ * directly under `Anything`.  A type cannot belong to both: occurrences
+ * (things that exist in space/time — parts, items, actions, ports, …) are
+ * disjoint from data values (attributes, enumerations).  A specialization
+ * that crosses this boundary is a type error.
+ */
+export enum TypeFamily {
+    /** Structural / behavioural things (rooted at `Occurrence`). */
+    Occurrence = 'occurrence',
+    /** Data values (rooted at `DataValue`). */
+    DataValue = 'data',
+}
+
+/** Return the simple (unqualified) name — the last `::`-separated segment. */
+export function simpleName(reference: string): string {
+    const stripped = reference.replace(/^~/, '');
+    const idx = stripped.lastIndexOf('::');
+    return idx >= 0 ? stripped.slice(idx + 2) : stripped;
+}
+
+/**
+ * A directed graph of super-type relationships with kinded edges.
+ */
+export class SuperTypeGraph {
+    /** Adjacency list: node simple name → its outgoing super-type edges. */
+    private readonly edges = new Map<string, SuperTypeEdge[]>();
+
+    /** Add a kinded super-type edge from `source` to `reference`. */
+    addEdge(source: string, reference: string, kind: EdgeKind): void {
+        const from = simpleName(source);
+        const target = simpleName(reference);
+        if (!from || !target || from === target) return; // ignore empty / self-loops
+
+        let list = this.edges.get(from);
+        if (!list) {
+            list = [];
+            this.edges.set(from, list);
+        }
+        // De-duplicate identical (target, kind) edges.
+        if (list.some(e => e.target === target && e.kind === kind)) return;
+        list.push({ target, kind, reference });
+    }
+
+    /** Get the outgoing super-type edges declared directly on `name`. */
+    getSupertypeEdges(name: string): readonly SuperTypeEdge[] {
+        return this.edges.get(simpleName(name)) ?? [];
+    }
+
+    /**
+     * Depth-first search: does `sub` specialize `sup` (directly or
+     * transitively) following super-type edges?
+     *
+     * @param sub  the candidate sub-type name (qualified or simple)
+     * @param sup  the candidate super-type name (qualified or simple)
+     * @param edgeKinds optional set restricting which edge kinds may be
+     *   traversed.  When omitted, every edge kind is followed.
+     */
+    specializes(sub: string, sup: string, edgeKinds?: ReadonlySet<EdgeKind>): boolean {
+        const start = simpleName(sub);
+        const goal = simpleName(sup);
+        if (start === goal) return true;
+
+        const visited = new Set<string>();
+        const stack: string[] = [start];
+        while (stack.length > 0) {
+            const current = stack.pop()!;
+            if (visited.has(current)) continue;
+            visited.add(current);
+
+            for (const edge of this.edges.get(current) ?? []) {
+                if (edgeKinds && !edgeKinds.has(edge.kind)) continue;
+                if (edge.target === goal) return true;
+                if (!visited.has(edge.target)) stack.push(edge.target);
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Collect every (transitive) super-type of `name`, including the
+     * starting node itself.  Uses the same DFS traversal as
+     * {@link specializes}.
+     */
+    collectSupertypes(name: string, edgeKinds?: ReadonlySet<EdgeKind>): Set<string> {
+        const result = new Set<string>();
+        const start = simpleName(name);
+        const stack: string[] = [start];
+        while (stack.length > 0) {
+            const current = stack.pop()!;
+            if (result.has(current)) continue;
+            result.add(current);
+            for (const edge of this.edges.get(current) ?? []) {
+                if (edgeKinds && !edgeKinds.has(edge.kind)) continue;
+                if (!result.has(edge.target)) stack.push(edge.target);
+            }
+        }
+        return result;
+    }
+
+    /** Total number of nodes with at least one outgoing edge (for tests). */
+    get nodeCount(): number {
+        return this.edges.size;
+    }
+}
+
+/**
+ * Build a {@link SuperTypeGraph} from a set of symbols.
+ *
+ * Edges are created from:
+ *  - explicit specialization (`:>`) on definitions → {@link EdgeKind.Specialization}
+ *  - explicit subsetting (`:>`) on usages → {@link EdgeKind.Subsetting}
+ *  - feature typing (`:`) on usages → {@link EdgeKind.FeatureTyping}
+ *  - the injected implicit default super-type for each definition kind →
+ *    {@link EdgeKind.Implicit}
+ *
+ * The fixed standard-library root hierarchy (`Part :> Item :> …`) is always
+ * seeded so cross-kind reasoning works even when the library itself is not
+ * present in the symbol set.
+ */
+export function buildSuperTypeGraph(symbols: readonly SysMLSymbol[]): SuperTypeGraph {
+    const graph = new SuperTypeGraph();
+
+    // Seed the standard-library implicit root hierarchy.
+    for (const [sub, sup] of BASE_TYPE_HIERARCHY) {
+        graph.addEdge(sub, sup, EdgeKind.Implicit);
+    }
+
+    for (const symbol of symbols) {
+        const def = isDefinition(symbol.kind);
+
+        if (def) {
+            // Definitions: `typeNames` and `specializationNames` are super-types.
+            for (const tn of symbol.typeNames) {
+                graph.addEdge(symbol.name, tn, EdgeKind.Specialization);
+            }
+            for (const sn of symbol.specializationNames) {
+                graph.addEdge(symbol.name, sn, EdgeKind.Specialization);
+            }
+
+            // Inject the implicit default super-type for this kind.
+            const implicit = IMPLICIT_DEFINITION_SUPERTYPES.get(symbol.kind);
+            if (implicit) {
+                graph.addEdge(symbol.name, implicit, EdgeKind.Implicit);
+            }
+        } else {
+            // Usages: `:` typing and `:>` subsetting / `:>>` redefinition.
+            for (const tn of symbol.typeNames) {
+                graph.addEdge(symbol.name, tn, EdgeKind.FeatureTyping);
+            }
+            for (const sn of symbol.specializationNames) {
+                graph.addEdge(symbol.name, sn, EdgeKind.Subsetting);
+            }
+        }
+    }
+
+    return graph;
+}
+
+/**
+ * Classify a type into one of the two disjoint top-level {@link TypeFamily}
+ * branches by walking its super-types via DFS, or `undefined` when the type
+ * is not connected to either root (e.g. an unknown / external type).
+ *
+ * Note: when a type is (incorrectly) connected to *both* roots — which only
+ * happens in the presence of a malformed cross-family specialization — no
+ * decision is made.  To classify a definition by its declared kind alone
+ * (independent of its possibly-erroneous edges), use
+ * {@link familyOfDefinitionKind}.
+ */
+export function classifyFamily(graph: SuperTypeGraph, name: string): TypeFamily | undefined {
+    const supertypes = graph.collectSupertypes(name);
+    const isOccurrence = supertypes.has('Occurrence');
+    const isData = supertypes.has('DataValue');
+    // If somehow connected to both (malformed input), prefer no decision.
+    if (isOccurrence && !isData) return TypeFamily.Occurrence;
+    if (isData && !isOccurrence) return TypeFamily.DataValue;
+    return undefined;
+}
+
+/**
+ * The simple (unqualified) name of the implicit root super-type for a
+ * definition kind, or `undefined` when the kind has no implicit root.
+ * e.g. `PartDef` → `Part`, `AttributeDef` → `DataValue`.
+ */
+export function implicitRootName(kind: SysMLElementKind): string | undefined {
+    const qualified = IMPLICIT_DEFINITION_SUPERTYPES.get(kind);
+    return qualified ? simpleName(qualified) : undefined;
+}
+
+/**
+ * Classify a definition into its top-level {@link TypeFamily} purely from its
+ * element kind, via the implicit default super-type for that kind.  This is
+ * deterministic and unaffected by any (possibly erroneous) explicit
+ * specialization edges the definition declares.
+ */
+export function familyOfDefinitionKind(kind: SysMLElementKind): TypeFamily | undefined {
+    const implicitRoot = IMPLICIT_DEFINITION_SUPERTYPES.get(kind);
+    if (!implicitRoot) return undefined;
+    return simpleName(implicitRoot) === 'DataValue'
+        ? TypeFamily.DataValue
+        : TypeFamily.Occurrence;
+}
+

--- a/server/src/providers/semanticValidator.ts
+++ b/server/src/providers/semanticValidator.ts
@@ -4,6 +4,13 @@ import { getLibraryPackageNames, resolveLibraryType } from '../library/libraryIn
 import { SysMLModelProvider } from '../model/sysmlModelProvider.js';
 import { SysMLElementKind, SysMLSymbol, isDefinition } from '../symbols/sysmlElements.js';
 import { stripComments } from '../utils/identUtils.js';
+import {
+    buildSuperTypeGraph,
+    familyOfDefinitionKind,
+    implicitRootName,
+    SuperTypeGraph,
+    TypeFamily,
+} from '../analysis/typeGraph.js';
 
 /**
  * Standard library types that are always available (from Kernel libraries).
@@ -113,6 +120,12 @@ export class SemanticValidator {
     /** Cached library package names — never changes after init. */
     private libraryNamesCache?: Set<string>;
 
+    /** Cached super-type graph, invalidated when the workspace symbol set changes. */
+    private typeGraphCache?: {
+        symbols: SysMLSymbol[];
+        graph: SuperTypeGraph;
+    };
+
     constructor(private readonly documentManager: DocumentManager) {
         this.modelProvider = new SysMLModelProvider(documentManager);
     }
@@ -180,6 +193,7 @@ export class SemanticValidator {
 
         const text = this.documentManager.getText(uri) ?? '';
         const indexes = this.getOrBuildIndexes(allSymbols);
+        const typeGraph = this.getOrBuildTypeGraph(allSymbols);
 
         const diagnostics: Diagnostic[] = [];
 
@@ -200,6 +214,7 @@ export class SemanticValidator {
         diagnostics.push(...this.checkConstraintBodyReferences(text, uri, symbols, indexes));
         diagnostics.push(...this.checkCircularSpecialization(symbols, indexes));
         diagnostics.push(...this.checkCircularContainment(symbols, indexes));
+        diagnostics.push(...this.checkSpecializationConformance(symbols, indexes, typeGraph));
         diagnostics.push(...this.checkUnsatisfiedRequirements(symbols, indexes));
         diagnostics.push(...this.checkUnverifiedRequirements(symbols, indexes));
         diagnostics.push(...this.checkViewpointSatisfaction(symbols, indexes));
@@ -1166,6 +1181,124 @@ export class SemanticValidator {
             }
         }
         return hierarchy;
+    }
+
+    /**
+     * Build (or reuse a cached) super-type graph for the whole workspace.
+     *
+     * The graph is keyed on the identity of the `allSymbols` array returned
+     * by the workspace symbol table, which is replaced whenever any symbol is
+     * added or removed — so the cache is invalidated automatically.
+     */
+    private getOrBuildTypeGraph(allSymbols: SysMLSymbol[]): SuperTypeGraph {
+        if (this.typeGraphCache && this.typeGraphCache.symbols === allSymbols) {
+            return this.typeGraphCache.graph;
+        }
+        const graph = buildSuperTypeGraph(allSymbols);
+        this.typeGraphCache = { symbols: allSymbols, graph };
+        return graph;
+    }
+
+    /**
+     * Rule: incompatible specialization.
+     *
+     * A definition may only specialize (`:>` / `specializes`) another type
+     * whose implicit library root lies on the same generalization line.
+     * SysML v2 roots every definition kind at a standard-library type
+     * (`part def` → `Parts::Part`, `attribute def` → `Base::DataValue`, …)
+     * and those roots form a fixed hierarchy (`Part :> Item :> Object :>
+     * Occurrence`, `DataValue`, …) under `Anything`.
+     *
+     * The super-type graph seeds that backbone hierarchy, so a depth-first
+     * search (DFS) between the two roots decides compatibility: a part def
+     * specializing an item def is valid (`Part :> Item`), whereas a part def
+     * specializing an attribute def is not (occurrences and data values are
+     * disjoint).  Unresolved / library / lowercase feature references are
+     * skipped to avoid false positives.
+     */
+    private checkSpecializationConformance(
+        symbolsInUri: SysMLSymbol[],
+        indexes: SymbolIndexes,
+        graph: SuperTypeGraph,
+    ): Diagnostic[] {
+        const diagnostics: Diagnostic[] = [];
+
+        for (const symbol of symbolsInUri) {
+            if (!isDefinition(symbol.kind)) continue;
+
+            const subRoot = implicitRootName(symbol.kind);
+            if (subRoot === undefined) continue;
+
+            // Explicit specialization targets are captured in typeNames /
+            // specializationNames for definitions.
+            const refs = new Set<string>([
+                ...symbol.typeNames,
+                ...symbol.specializationNames,
+            ]);
+
+            for (const ref of refs) {
+                // Resolve the reference to a user-defined definition; only
+                // those carry a reliable kind we can classify.  Skip
+                // lowercase feature references (subsetting of a feature, not a
+                // type) and unresolved/library names to avoid false positives.
+                const target = this.resolveDefinitionRef(ref, indexes);
+                if (!target || target.qualifiedName === symbol.qualifiedName) continue;
+
+                const supRoot = implicitRootName(target.kind);
+                if (supRoot === undefined || supRoot === subRoot) continue;
+
+                // DFS over the standard-library root backbone: the
+                // specialization is valid when either root is reachable from
+                // the other (e.g. Part :> Item).  Only flag when neither is.
+                if (graph.specializes(subRoot, supRoot) || graph.specializes(supRoot, subRoot)) {
+                    continue;
+                }
+
+                const subFamily = familyOfDefinitionKind(symbol.kind);
+                const supFamily = familyOfDefinitionKind(target.kind);
+                const detail = (subFamily !== undefined && supFamily !== undefined && subFamily !== supFamily)
+                    ? `${this.familyLabel(subFamily)} and ${this.familyLabel(supFamily)} types belong to disjoint type families`
+                    : `'${subRoot}' and '${supRoot}' are unrelated in the SysML type hierarchy`;
+
+                diagnostics.push({
+                    severity: DiagnosticSeverity.Error,
+                    range: symbol.selectionRange,
+                    message:
+                        `Incompatible specialization: '${symbol.name}' (${symbol.kind}) ` +
+                        `cannot specialize '${target.name}' (${target.kind}) — ${detail}`,
+                    source: 'sysml',
+                    code: 'incompatible-specialization',
+                    data: { typeName: target.name },
+                });
+            }
+        }
+
+        return diagnostics;
+    }
+
+    /** Human-readable label for a type family, used in diagnostics. */
+    private familyLabel(family: TypeFamily): string {
+        return family === TypeFamily.DataValue ? 'data value' : 'occurrence';
+    }
+
+    /**
+     * Resolve a specialization reference to a single user-defined definition
+     * symbol, or `undefined` when it does not unambiguously name one (e.g. a
+     * lowercase feature reference, a library type, or an unresolved name).
+     */
+    private resolveDefinitionRef(ref: string, indexes: SymbolIndexes): SysMLSymbol | undefined {
+        // Use the last segment of qualified names (e.g. `Pkg::Foo` → `Foo`).
+        const name = ref.split('::').pop() ?? ref;
+        if (!name) return undefined;
+
+        // Lowercase leading character → feature reference (subsetting), not a type.
+        const ch0 = name.charCodeAt(0);
+        if (ch0 >= 97 && ch0 <= 122) return undefined;
+
+        const defs = (indexes.definitionsByName.get(name) ?? [])
+            .filter(s => isDefinition(s.kind));
+        // Only act when the name resolves unambiguously to one definition.
+        return defs.length === 1 ? defs[0] : undefined;
     }
 
     /**

--- a/test/unit/diagnostics.test.ts
+++ b/test/unit/diagnostics.test.ts
@@ -195,6 +195,70 @@ package Test {
         });
     });
 
+    describe('incompatible specialization (super-type graph)', () => {
+        it('should flag a part def specializing an attribute def', async () => {
+            const text = `
+package Test {
+    attribute def Mass;
+    part def Wheel :> Mass;
+}
+`;
+            const diags = await getSemanticDiagnostics(text);
+            const incompat = diags.filter(d => d.code === 'incompatible-specialization');
+            expect(incompat.length).toBeGreaterThanOrEqual(1);
+            expect(incompat[0].message).toContain("'Wheel'");
+            expect(incompat[0].message).toContain("'Mass'");
+        });
+
+        it('should flag an attribute def specializing a part def', async () => {
+            const text = `
+package Test {
+    part def Person;
+    attribute def ForceUnit :> Person;
+}
+`;
+            const diags = await getSemanticDiagnostics(text);
+            const incompat = diags.filter(d => d.code === 'incompatible-specialization');
+            expect(incompat.length).toBeGreaterThanOrEqual(1);
+        });
+
+        it('should NOT flag a part def specializing another part def', async () => {
+            const text = `
+package Test {
+    part def Vehicle;
+    part def Car :> Vehicle;
+}
+`;
+            const diags = await getSemanticDiagnostics(text);
+            const incompat = diags.filter(d => d.code === 'incompatible-specialization');
+            expect(incompat.length).toBe(0);
+        });
+
+        it('should NOT flag a part def specializing an item def (compatible families)', async () => {
+            // Part specializes Item in the standard library, so this is valid.
+            const text = `
+package Test {
+    item def Cargo;
+    part def Container :> Cargo;
+}
+`;
+            const diags = await getSemanticDiagnostics(text);
+            const incompat = diags.filter(d => d.code === 'incompatible-specialization');
+            expect(incompat.length).toBe(0);
+        });
+
+        it('should NOT flag specialization of unresolved / library types', async () => {
+            const text = `
+package Test {
+    part def Wheel :> UnknownThing;
+}
+`;
+            const diags = await getSemanticDiagnostics(text);
+            const incompat = diags.filter(d => d.code === 'incompatible-specialization');
+            expect(incompat.length).toBe(0);
+        });
+    });
+
     describe('invalid multiplicity bounds', () => {
         it('should flag when lower bound exceeds upper bound', async () => {
             const text = `

--- a/test/unit/typeGraph.test.ts
+++ b/test/unit/typeGraph.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import {
+    buildSuperTypeGraph,
+    classifyFamily,
+    EdgeKind,
+    IMPLICIT_DEFINITION_SUPERTYPES,
+    simpleName,
+    SuperTypeGraph,
+    TypeFamily,
+} from '../../server/src/analysis/typeGraph.js';
+import { SysMLElementKind, SysMLSymbol } from '../../server/src/symbols/sysmlElements.js';
+
+/** Minimal symbol factory for graph tests. */
+function sym(
+    name: string,
+    kind: SysMLElementKind,
+    opts: { typeNames?: string[]; specializationNames?: string[] } = {},
+): SysMLSymbol {
+    const range = { start: { line: 0, character: 0 }, end: { line: 0, character: 0 } };
+    return {
+        name,
+        kind,
+        qualifiedName: name,
+        range,
+        selectionRange: range,
+        uri: 'file:///t.sysml',
+        typeNames: opts.typeNames ?? [],
+        specializationNames: opts.specializationNames ?? [],
+        children: [],
+    };
+}
+
+describe('simpleName', () => {
+    it('returns the last segment of a qualified name', () => {
+        expect(simpleName('ISQ::MassValue')).toBe('MassValue');
+        expect(simpleName('A::B::C')).toBe('C');
+    });
+
+    it('returns the name unchanged when unqualified', () => {
+        expect(simpleName('Part')).toBe('Part');
+    });
+
+    it('strips a leading conjugation tilde', () => {
+        expect(simpleName('~Port')).toBe('Port');
+    });
+});
+
+describe('SuperTypeGraph', () => {
+    it('does not create self-loops', () => {
+        const g = new SuperTypeGraph();
+        g.addEdge('A', 'A', EdgeKind.Specialization);
+        expect(g.getSupertypeEdges('A')).toHaveLength(0);
+    });
+
+    it('de-duplicates identical edges', () => {
+        const g = new SuperTypeGraph();
+        g.addEdge('A', 'B', EdgeKind.Specialization);
+        g.addEdge('A', 'B', EdgeKind.Specialization);
+        expect(g.getSupertypeEdges('A')).toHaveLength(1);
+    });
+
+    it('records the kind on each edge', () => {
+        const g = new SuperTypeGraph();
+        g.addEdge('A', 'B', EdgeKind.Subsetting);
+        expect(g.getSupertypeEdges('A')[0].kind).toBe(EdgeKind.Subsetting);
+    });
+
+    it('finds direct and transitive specialization via DFS', () => {
+        const g = new SuperTypeGraph();
+        g.addEdge('A', 'B', EdgeKind.Specialization);
+        g.addEdge('B', 'C', EdgeKind.Specialization);
+        expect(g.specializes('A', 'B')).toBe(true);
+        expect(g.specializes('A', 'C')).toBe(true); // transitive
+        expect(g.specializes('A', 'A')).toBe(true); // reflexive
+        expect(g.specializes('C', 'A')).toBe(false);
+    });
+
+    it('terminates on cyclic graphs', () => {
+        const g = new SuperTypeGraph();
+        g.addEdge('A', 'B', EdgeKind.Specialization);
+        g.addEdge('B', 'A', EdgeKind.Specialization);
+        expect(g.specializes('A', 'C')).toBe(false);
+        expect(g.specializes('A', 'B')).toBe(true);
+    });
+
+    it('can restrict traversal to specific edge kinds', () => {
+        const g = new SuperTypeGraph();
+        g.addEdge('A', 'B', EdgeKind.FeatureTyping);
+        g.addEdge('B', 'C', EdgeKind.Specialization);
+        // Following only specialization edges, A cannot reach B.
+        expect(g.specializes('A', 'C', new Set([EdgeKind.Specialization]))).toBe(false);
+        // Following all edges, it can.
+        expect(g.specializes('A', 'C')).toBe(true);
+    });
+
+    it('collects all transitive supertypes including itself', () => {
+        const g = new SuperTypeGraph();
+        g.addEdge('A', 'B', EdgeKind.Specialization);
+        g.addEdge('B', 'C', EdgeKind.Specialization);
+        const supers = g.collectSupertypes('A');
+        expect([...supers].sort()).toEqual(['A', 'B', 'C']);
+    });
+});
+
+describe('buildSuperTypeGraph — implicit default supertypes', () => {
+    it('injects Parts::Part for a part def (e.g. part def Wheel -> Part)', () => {
+        const g = buildSuperTypeGraph([sym('Wheel', SysMLElementKind.PartDef)]);
+        expect(g.specializes('Wheel', 'Part')).toBe(true);
+        const implicitEdge = g.getSupertypeEdges('Wheel')
+            .find(e => e.target === 'Part');
+        expect(implicitEdge?.kind).toBe(EdgeKind.Implicit);
+        expect(implicitEdge?.reference).toBe('Parts::Part');
+    });
+
+    it('maps every definition kind to a documented implicit supertype', () => {
+        expect(IMPLICIT_DEFINITION_SUPERTYPES.get(SysMLElementKind.PartDef)).toBe('Parts::Part');
+        expect(IMPLICIT_DEFINITION_SUPERTYPES.get(SysMLElementKind.ItemDef)).toBe('Items::Item');
+        expect(IMPLICIT_DEFINITION_SUPERTYPES.get(SysMLElementKind.ActionDef)).toBe('Actions::Action');
+        expect(IMPLICIT_DEFINITION_SUPERTYPES.get(SysMLElementKind.AttributeDef)).toBe('Base::DataValue');
+    });
+
+    it('walks user specialization through to the injected library root', () => {
+        // part def SportsCar :> Car; part def Car;  =>  SportsCar -> Car -> Part
+        const g = buildSuperTypeGraph([
+            sym('Car', SysMLElementKind.PartDef),
+            sym('SportsCar', SysMLElementKind.PartDef, { typeNames: ['Car'] }),
+        ]);
+        expect(g.specializes('SportsCar', 'Car')).toBe(true);
+        expect(g.specializes('SportsCar', 'Part')).toBe(true);
+        expect(g.specializes('SportsCar', 'Item')).toBe(true); // Part :> Item (library root)
+    });
+
+    it('does not inject an implicit supertype for usages', () => {
+        const g = buildSuperTypeGraph([sym('wheel', SysMLElementKind.PartUsage)]);
+        expect(g.specializes('wheel', 'Part')).toBe(false);
+    });
+});
+
+describe('classifyFamily', () => {
+    it('classifies a part def as the occurrence family', () => {
+        const g = buildSuperTypeGraph([sym('Wheel', SysMLElementKind.PartDef)]);
+        expect(classifyFamily(g, 'Wheel')).toBe(TypeFamily.Occurrence);
+    });
+
+    it('classifies an attribute def as the data-value family', () => {
+        const g = buildSuperTypeGraph([sym('Mass', SysMLElementKind.AttributeDef)]);
+        expect(classifyFamily(g, 'Mass')).toBe(TypeFamily.DataValue);
+    });
+
+    it('returns undefined for an unconnected/unknown type', () => {
+        const g = buildSuperTypeGraph([]);
+        expect(classifyFamily(g, 'Mystery')).toBeUndefined();
+    });
+});


### PR DESCRIPTION
This pull request introduces a comprehensive super-type graph for SysML v2 type checking, enhances the semantic validator to leverage this graph for better type error diagnostics, and adds detailed example files that illustrate both allowed and erroneous type patterns. The changes significantly improve the language server's ability to reason about type hierarchies, detect cross-family specialization errors, and provide clear diagnostics to users.

**Type System Infrastructure Enhancements:**

- Introduced `server/src/analysis/typeGraph.ts`, which implements a directed, kinded super-type graph for SysML v2. This graph models generalization relationships, injects implicit root types, seeds the standard library backbone hierarchy, and provides DFS-based queries for specialization and type family classification.
- Updated the architecture documentation (`ARCHITECTURE.md`) to describe the new analysis layer and its role in type checking and complexity analysis.

**Semantic Validation Improvements:**

- Enhanced the semantic validator (`server/src/providers/semanticValidator.ts`) to cache and use the new super-type graph, enabling more robust and accurate type error checks, including incompatible specialization across disjoint type families. [[1]](diffhunk://#diff-c8901b845badbb29f37b0bfee687720f1f4857e2fb4baf95db79f28671eb8032R7-R13) [[2]](diffhunk://#diff-c8901b845badbb29f37b0bfee687720f1f4857e2fb4baf95db79f28671eb8032R123-R128) [[3]](diffhunk://#diff-c8901b845badbb29f37b0bfee687720f1f4857e2fb4baf95db79f28671eb8032R196) [[4]](diffhunk://#diff-c8901b845badbb29f37b0bfee687720f1f4857e2fb4baf95db79f28671eb8032R217)

**Example and Test Coverage:**

- Added `examples/type-errors.sysml`, a comprehensive file containing deliberate semantic errors, each annotated with the expected diagnostic code for validation and testing purposes.
- Added `examples/allowed-cycles.sysml`, demonstrating valid recursive and self-referential type patterns that should not trigger cycle diagnostics, serving as a reference for correct language server behavior.